### PR TITLE
CLOUD-932 specified main class for periscope build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ apply plugin: 'license-report'
 
 sourceCompatibility = 1.7
 group = 'com.sequenceiq'
+mainClassName = 'com.sequenceiq.periscope.PeriscopeApplication'
 
 allprojects {
     ext.config = new ConfigSlurper(env).parse(file("$rootDir/gradle/config/buildConfig.groovy").toURL())


### PR DESCRIPTION
@keyki 

The first build after the checkout of the project always failed with "No value has been specified for property 'mainClassName'."